### PR TITLE
builder/docker: Use -a option when pushing

### DIFF
--- a/pkg/builder/docker/builder.go
+++ b/pkg/builder/docker/builder.go
@@ -79,6 +79,7 @@ func Build(ctx *context.Context, cfg *config.Configuration) error {
 		cfg.GetVerbose(),
 		"docker",
 		"push",
+		"-a",
 		cfg.GetBuilder().GetImage(),
 	)
 }


### PR DESCRIPTION
### What does this PR do ?

This PR makes ubuild passing explicitely the `-a` flag to push all known images when calling `docker push`.

Indeed, Docker 20.04 introduced a [breaking change](https://github.com/docker/cli/pull/2220) that only pushes `:latest` when docker push is run without an explicit tag.

And this brand new version comes with `Ubuntu 20.04` which starts to [rollout progressively](https://github.com/actions/virtual-environments/issues/1816#issuecomment-773125315)  on github actions.